### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - New action: "Go to {systemName}": Go to the URL defined by `siteUrl`
+- Show the badge count when rendering utility items (for actions like "Updates")
 
 ## 1.0.0 - 2022-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Palette
 
+## 1.1.0 - 2022-02-07
+
+### Added
+- New action: "Go to {systemName}": Go to the URL defined by `siteUrl`
+
 ## 1.0.0 - 2022-02-03
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "trendyminds/craft-palette",
   "description": "A command palette to easily jump to specific areas within Craft",
   "type": "craft-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "keywords": ["palette", "craft", "craft cms", "cmdk", "spotlight", "craft plugin"],
   "license": "MIT",
   "authors": [

--- a/src/controllers/ActionsController.php
+++ b/src/controllers/ActionsController.php
@@ -87,7 +87,10 @@ class ActionsController extends Controller
 	{
 		return collect(Craft::$app->getUtilities()->getAuthorizedUtilityTypes())
 			->map(fn($class) => [
-				'name' => $class::displayName(),
+				'name' =>
+					$class::badgeCount()
+					? "{$class::displayName()} ({$class::badgeCount()})"
+					: $class::displayName(),
 				'subtitle' => 'Utilities',
 				'icon' => 'AdjustmentsIcon',
 				'url' => UrlHelper::cpUrl("utilities/{$class::id()}"),

--- a/src/controllers/ActionsController.php
+++ b/src/controllers/ActionsController.php
@@ -69,6 +69,12 @@ class ActionsController extends Controller
 					'url' => UrlHelper::cpUrl($url),
 				];
 			})
+			->prepend([
+				'name' => Craft::$app->getSystemName(),
+				'subtitle' => "Go to " . UrlHelper::siteUrl(),
+				'icon' => 'GlobeAltIcon',
+				'url' => UrlHelper::siteUrl()
+			])
 			->toArray();
 	}
 


### PR DESCRIPTION
## 1.1.0 - 2022-02-07

### Added
- New action: "Go to {systemName}": Go to the URL defined by `siteUrl`
- Show the badge count when rendering utility items (for actions like "Updates")