### PR TITLE
[Performance] Prevent Palette from making requests if not accessCp

### DIFF
--- a/src/Palette.php
+++ b/src/Palette.php
@@ -16,8 +16,6 @@ class Palette extends Plugin
     {
         parent::init();
 
-        // something is causing alot of transactions here Ima find it
-
         // Define our alias for referencing the asset bundles (CSS/JS)
         Craft::setAlias('@trendyminds/palette', $this->getBasePath());
 


### PR DESCRIPTION
I noticed Palette was making a lot of queries even though a user has no access to the cp. 
<img width="706" alt="Screenshot 2023-03-06 at 9 48 15 AM" src="https://user-images.githubusercontent.com/20300635/223272987-eb656797-2e50-4fcc-a406-dc90b04bd12e.png">

This change should prevent this and also gets rid of a warning i noticed because some of the settings conditions are making request before craft was fully init. This yellow warning here.
<img width="1126" alt="Screenshot 2023-03-06 at 5 37 33 PM" src="https://user-images.githubusercontent.com/20300635/223274077-d2fd35cf-331b-4651-a6a0-7f3f0d287ae1.png">

You can override settings to show debug bar like this here
 ```
$request = Craft::$app->getRequest();
  $request->headers->set('X-Debug', 'enable');
```