### PR TITLE
3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Palette
 
+## 3.2.2 - 2023-07-12
+
+### Fixed
+- Swap `UrlHelper::baseUrl()` for `UrlHelper::siteUrl()` for better URL compatibility ([Discussion](https://github.com/trendyminds/craft-palette/discussions/27))
+
 ## 3.2.1 - 2023-07-12
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "trendyminds/craft-palette",
   "description": "A command palette to easily jump to specific areas within Craft",
   "type": "craft-plugin",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "keywords": ["palette", "craft", "craft cms", "cmdk", "spotlight", "craft plugin"],
   "license": "MIT",
   "authors": [

--- a/src/controllers/ActionsController.php
+++ b/src/controllers/ActionsController.php
@@ -60,7 +60,7 @@ class ActionsController extends Controller
         $actions = collect((new Cp())->nav())
             ->map(function ($i) {
                 $url = str_replace(
-                    UrlHelper::baseUrl(),
+                    UrlHelper::siteUrl(),
                     '',
                     $i['url']
                 );
@@ -201,7 +201,7 @@ class ActionsController extends Controller
 
             // Normalize the referrer and the Craft base URL
             $referrer = rtrim($referrer, '/').'/';
-            $url = rtrim(UrlHelper::baseUrl(), '/').'/';
+            $url = rtrim(UrlHelper::siteUrl(), '/').'/';
 
             // Pluck out the URI using the referrer and the Craft base URL
             $uri = str_replace($url, '', $referrer);
@@ -245,7 +245,7 @@ class ActionsController extends Controller
         $referrer = Craft::$app->getRequest()->referrer;
 
         $uri = str_replace(
-            UrlHelper::baseUrl(),
+            UrlHelper::siteUrl(),
             '',
             $referrer
         );


### PR DESCRIPTION
## 3.2.2 - 2023-07-12

### Fixed
- Swap `UrlHelper::baseUrl()` for `UrlHelper::siteUrl()` for better URL compatibility ([Discussion](https://github.com/trendyminds/craft-palette/discussions/27))